### PR TITLE
Bump versions for 0.7.0 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Gabriel Coutinho de Paula <gcdepaula@protonmail.io>
+Roman Hodulák <hodulakr@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
+
+## [0.7.0] - 2023-08-10
 ### Changes
 - Publish crates to crates.io instead of the `cartesi` private registry.
 - Remove all mentions of the `cartesi` private registry.
@@ -14,6 +17,7 @@ particular was chosen as it is specific to the Ethereum base layer.
 - Rewrite readme.
 - Remove outdated examples.
 - Trigger CI workflows only on relevant file types.
+- Update dependencies.
 
 ### Fixed
 - Apply all clippy suggestions; suppress warnings too complicated to
@@ -134,16 +138,17 @@ reestablishing it at every subscription attempt.
 ## [0.1.0] - 2021-12-28
 - Initial release
 
-[Unreleased]: https://github.com/cartesi-corp/state-fold/compare/v0.6.3...HEAD
-[0.6.3]: https://github.com/cartesi-corp/state-fold/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/cartesi-corp/state-fold/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/cartesi-corp/state-fold/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/cartesi-corp/state-fold/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/cartesi-corp/state-fold/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/cartesi-corp/state-fold/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/cartesi-corp/state-fold/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/cartesi-corp/state-fold/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/cartesi-corp/state-fold/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/cartesi-corp/state-fold/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/cartesi-corp/state-fold/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/cartesi-corp/state-fold/releases/tag/v0.1.0
+[Unreleased]: https://github.com/cartesi/state-fold/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/cartesi/state-fold/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/cartesi/state-fold/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/cartesi/state-fold/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/cartesi/state-fold/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/cartesi/state-fold/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/cartesi/state-fold/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/cartesi/state-fold/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/cartesi/state-fold/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/cartesi/state-fold/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/cartesi/state-fold/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/cartesi/state-fold/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/cartesi/state-fold/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/cartesi/state-fold/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ members = [
 ]
 
 [workspace.dependencies]
-eth-state-fold-types = { version = "0.6", path = "state-fold-types" }
-eth-block-history = { version = "0.6", path = "block-history" }
-eth-state-fold = { version = "0.6", path = "state-fold" }
-eth-state-server-common = { version = "0.6", path = "state-server-common" }
+eth-state-fold-types = { version = "0.7", path = "state-fold-types" }
+eth-block-history = { version = "0.7", path = "block-history" }
+eth-state-fold = { version = "0.7", path = "state-fold" }
+eth-state-server-common = { version = "0.7", path = "state-server-common" }
 eth-state-fold-test = { version = "*", path = "state-fold-test" }
 
 ethabi = "18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,16 @@ members = [
   "state-fold-test",
 ]
 
+[workspace.package]
+version = "0.7.0"
+license = "Apache-2.0"
+authors = [
+  "Gabriel Coutinho de Paula <gcdepaula@protonmail.io>",
+  "Roman Hodulák <hodulakr@gmail.com>",
+]
+homepage = "https://github.com/cartesi/state-fold"
+edition = "2021"
+
 [workspace.dependencies]
 eth-state-fold-types = { version = "0.7", path = "state-fold-types" }
 eth-block-history = { version = "0.7", path = "block-history" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,12 @@
 [workspace]
 resolver = "2"
 members = [
+  # Core crates (in dependency order)
+  "state-fold-types",
   "block-history",
   "state-fold",
-  "state-fold-types",
+
+  # gRPC crates
   "state-server-common",
   "state-client-lib",
   "state-server-lib",
@@ -13,11 +16,32 @@ members = [
 ]
 
 [workspace.dependencies]
+eth-state-fold-types = { version = "0.6", path = "state-fold-types" }
 eth-block-history = { version = "0.6", path = "block-history" }
 eth-state-fold = { version = "0.6", path = "state-fold" }
-eth-state-fold-types = { version = "0.6", path = "state-fold-types" }
 eth-state-server-common = { version = "0.6", path = "state-server-common" }
-eth-state-client-lib = { version = "0.6", path = "state-client-lib" }
-eth-state-server-lib = { version = "0.6", path = "state-server-lib" }
+eth-state-fold-test = { version = "*", path = "state-fold-test" }
 
-eth-state-fold-test = { path = "state-fold-test" }
+ethabi = "18"
+ethers = "1.0"
+
+anyhow = "1"
+async-recursion = "1"
+async-stream = "0.3"
+async-trait = "0.1"
+clap = "4.2"
+futures = "0.3"
+hex = "0.4"
+proc-macro2 = "1"
+prost = "0.11"
+quote = "1"
+serde = "1"
+serde_json = "1"
+snafu = "0.7"
+tokio = "1"
+tokio-stream = "0.1"
+toml = "0.5"
+tonic = "0.9"
+tonic-build = "0.9"
+tonic-health = "0.9"
+tracing = "0.1"

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-      Copyright 2019 Cartesi Pte. Ltd.
+      Copyright Cartesi and individual authors
 
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/block-history/Cargo.toml
+++ b/block-history/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2021"
 [dependencies]
 eth-state-fold-types = { workspace = true, features = ["ethers"] }
 
-snafu = "0.7"
-clap = { version = "4.1", features = ["derive", "env"] }
+snafu = { workspace = true }
+clap = { features = ["derive", "env"] , workspace = true }
 
-async-stream = "0.3"
-tokio = { version = "1", features = ["sync", "macros"] }
-tokio-stream = "0.1"
-tracing = "0.1"
+async-stream = { workspace = true }
+tokio = { features = ["sync", "macros"] , workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
 
 
 [dev-dependencies]

--- a/block-history/Cargo.toml
+++ b/block-history/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eth-block-history"
 license = "Apache-2.0"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
 homepage = "https://cartesi.io"
 edition = "2021"

--- a/block-history/Cargo.toml
+++ b/block-history/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "eth-block-history"
-license = "Apache-2.0"
-version = "0.7.0"
-authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
-homepage = "https://cartesi.io"
-edition = "2021"
+
+license = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+
 
 [dependencies]
 eth-state-fold-types = { workspace = true, features = ["ethers"] }

--- a/block-history/src/block_archive.rs
+++ b/block-history/src/block_archive.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::block_tree::BlockTree;
 
 use eth_state_fold_types::BlocksSince;

--- a/block-history/src/block_subscriber.rs
+++ b/block-history/src/block_subscriber.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::block_archive::{self, BlockArchive};
 
 use eth_state_fold_types::{

--- a/block-history/src/block_tree.rs
+++ b/block-history/src/block_tree.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_state_fold_types::ethereum_types::{H256, U64};
 use eth_state_fold_types::Block;
 

--- a/block-history/src/config.rs
+++ b/block-history/src/config.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use clap::Parser;
 use std::time::Duration;
 

--- a/block-history/src/lib.rs
+++ b/block-history/src/lib.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 mod block_archive;
 mod block_subscriber;
 mod block_tree;

--- a/block-history/tests/subscriber_test.rs
+++ b/block-history/tests/subscriber_test.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_block_history::BlockSubscriber;
 
 use eth_state_fold_types::{ethers, Block, BlockStreamItem};

--- a/state-client-lib/Cargo.toml
+++ b/state-client-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eth-state-client-lib"
 license = "Apache-2.0"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
 homepage = "https://cartesi.io"
 edition = "2021"

--- a/state-client-lib/Cargo.toml
+++ b/state-client-lib/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "eth-state-client-lib"
-license = "Apache-2.0"
-version = "0.7.0"
-authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
-homepage = "https://cartesi.io"
-edition = "2021"
+
+license = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+
 
 [dependencies]
 eth-state-fold-types = { workspace = true, features = ["ethers"] }

--- a/state-client-lib/Cargo.toml
+++ b/state-client-lib/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2021"
 eth-state-fold-types = { workspace = true, features = ["ethers"] }
 eth-state-server-common = { workspace = true, features = ["server"] }
 
-async-trait = "0.1"
-tonic = "0.8"
-tokio = { version = "1", features = ["sync"] }
-tokio-stream = "0.1"
+async-trait = { workspace = true }
+tonic = { workspace = true }
+tokio = { features = ["sync"] , workspace = true }
+tokio-stream = { workspace = true }
 
-serde = "1"
-serde_json = "1"
-snafu = "0.7"
-clap = { version = "4.1", features = ["derive", "env"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+clap = { features = ["derive", "env"] , workspace = true }

--- a/state-client-lib/src/config.rs
+++ b/state-client-lib/src/config.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use clap::Parser;
 use snafu::{ResultExt, Snafu};
 

--- a/state-client-lib/src/error.rs
+++ b/state-client-lib/src/error.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use serde_json;
 use snafu::Snafu;
 

--- a/state-client-lib/src/grpc_client.rs
+++ b/state-client-lib/src/grpc_client.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::{error::*, BlockServer, StateServer};
 
 use ethers::core::types::H256;

--- a/state-client-lib/src/interfaces.rs
+++ b/state-client-lib/src/interfaces.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::error::Result;
 
 use ethers::core::types::H256;

--- a/state-client-lib/src/lib.rs
+++ b/state-client-lib/src/lib.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 mod grpc_client;
 mod interfaces;
 

--- a/state-fold-test/Cargo.toml
+++ b/state-fold-test/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 
 [dependencies]
 eth-state-fold-types = { workspace = true }
-hex = "0.4"
-serde_json = "1.0"
-async-trait = "0.1"
-tokio = { version = "^1.5", features = ["sync"] }
+hex = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+tokio = { features = ["sync"] , workspace = true }
 
 [build-dependencies]
 eth-state-fold-types = { workspace = true, features = ["ethers"] }
-serde_json = "1"
-anyhow = "1"
-proc-macro2 = "1"
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/state-fold-test/Cargo.toml
+++ b/state-fold-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eth-state-fold-test"
 license = "Apache-2.0"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
 homepage = "https://cartesi.io"
 edition = "2021"

--- a/state-fold-test/Cargo.toml
+++ b/state-fold-test/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "eth-state-fold-test"
-license = "Apache-2.0"
-version = "0.7.0"
-authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
-homepage = "https://cartesi.io"
-edition = "2021"
 publish = false
+
+license = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+
 
 [dependencies]
 eth-state-fold-types = { workspace = true }

--- a/state-fold-test/build.rs
+++ b/state-fold-test/build.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_state_fold_types::contract;
 use std::error::Error;
 use std::fs;

--- a/state-fold-test/src/lib.rs
+++ b/state-fold-test/src/lib.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 #![allow(clippy::module_inception)]
 
 pub mod mock_middleware;

--- a/state-fold-test/src/mock_middleware.rs
+++ b/state-fold-test/src/mock_middleware.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_state_fold_types::ethers;
 use eth_state_fold_types::Block;
 use ethers::providers::{FromErr, Middleware, MockProvider};

--- a/state-fold-test/src/simple_storage.rs
+++ b/state-fold-test/src/simple_storage.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_state_fold_types::{contract, ethers};
 use ethers::{contract::Contract, providers::Middleware};
 use hex;

--- a/state-fold-test/src/utils.rs
+++ b/state-fold-test/src/utils.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_state_fold_types::ethers;
 use eth_state_fold_types::Block;
 use ethers::{

--- a/state-fold-types/Cargo.toml
+++ b/state-fold-types/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "eth-state-fold-types"
-license = "Apache-2.0"
-version = "0.7.0"
-authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
-homepage = "https://cartesi.io"
-edition = "2021"
+
+license = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+
 
 [dependencies]
 serde = { workspace = true }

--- a/state-fold-types/Cargo.toml
+++ b/state-fold-types/Cargo.toml
@@ -7,12 +7,12 @@ homepage = "https://cartesi.io"
 edition = "2021"
 
 [dependencies]
-serde = "1"
-ethers = { version = "1.0", optional = true, features = ["ws", "abigen", "rustls"] }
-ethabi = { version = "18" }
-serde_json = "1"
-toml = "0.5.8"
-anyhow = "1"
-proc-macro2 = "1"
-quote = "1"
-snafu = "0.7"
+serde = { workspace = true }
+ethers = { optional = true, features = ["ws", "abigen", "rustls"] , workspace = true }
+ethabi = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+anyhow = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+snafu = { workspace = true }

--- a/state-fold-types/Cargo.toml
+++ b/state-fold-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eth-state-fold-types"
 license = "Apache-2.0"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
 homepage = "https://cartesi.io"
 edition = "2021"

--- a/state-fold-types/src/config_utils.rs
+++ b/state-fold-types/src/config_utils.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use serde::de::DeserializeOwned;
 use snafu::{ResultExt, Snafu};
 use std::fs;

--- a/state-fold-types/src/contract.rs
+++ b/state-fold-types/src/contract.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use anyhow::{anyhow, Result};
 use ethers::contract::Abigen;
 use proc_macro2::token_stream::IntoIter;

--- a/state-fold-types/src/lib.rs
+++ b/state-fold-types/src/lib.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use ethereum_types::{Bloom, H256, U256, U64};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;

--- a/state-fold/Cargo.toml
+++ b/state-fold/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "eth-state-fold"
-license = "Apache-2.0"
-version = "0.7.0"
-authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
-homepage = "https://cartesi.io"
-edition = "2021"
+
+license = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+
 
 [dependencies]
 eth-state-fold-types = { workspace = true, features = ["ethers"] }

--- a/state-fold/Cargo.toml
+++ b/state-fold/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2021"
 eth-state-fold-types = { workspace = true, features = ["ethers"] }
 eth-block-history = { workspace = true }
 
-snafu = "0.7"
-clap = { version = "4.1", features = ["derive", "env"] }
+snafu = { workspace = true }
+clap = { features = ["derive", "env"] , workspace = true }
 
-async-recursion = "1"
-async-trait = "0.1"
-futures = "0.3"
-tokio = { version = "^1.5", features = ["sync"] }
+async-recursion = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+tokio = { features = ["sync"] , workspace = true }
 
 
 [dev-dependencies]

--- a/state-fold/Cargo.toml
+++ b/state-fold/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eth-state-fold"
 license = "Apache-2.0"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
 homepage = "https://cartesi.io"
 edition = "2021"

--- a/state-fold/src/config.rs
+++ b/state-fold/src/config.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use clap::Parser;
 use eth_state_fold_types::ethereum_types::U64;
 

--- a/state-fold/src/delegate_access/error.rs
+++ b/state-fold/src/delegate_access/error.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_state_fold_types::ethers;
 use ethers::providers::{FromErr, Middleware};
 

--- a/state-fold/src/delegate_access/fold_middleware.rs
+++ b/state-fold/src/delegate_access/fold_middleware.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use super::error::*;
 
 use eth_state_fold_types::ethers;

--- a/state-fold/src/delegate_access/mod.rs
+++ b/state-fold/src/delegate_access/mod.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 pub mod error;
 pub mod fold_middleware;
 pub mod sync_middleware;

--- a/state-fold/src/delegate_access/partition_events.rs
+++ b/state-fold/src/delegate_access/partition_events.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use tokio::sync::Semaphore;

--- a/state-fold/src/delegate_access/sync_middleware.rs
+++ b/state-fold/src/delegate_access/sync_middleware.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use super::error::*;
 use super::partition_events::*;
 

--- a/state-fold/src/delegate_access/utils.rs
+++ b/state-fold/src/delegate_access/utils.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use super::error::*;
 
 use eth_state_fold_types::ethers;

--- a/state-fold/src/env/archive.rs
+++ b/state-fold/src/env/archive.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::Foldable;
 
 use super::train::Train;

--- a/state-fold/src/env/environment.rs
+++ b/state-fold/src/env/environment.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::delegate_access::{FoldMiddleware, SyncMiddleware};
 use crate::error::*;
 use crate::Foldable;

--- a/state-fold/src/env/global_archive.rs
+++ b/state-fold/src/env/global_archive.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::Foldable;
 
 use super::archive::Archive;

--- a/state-fold/src/env/mod.rs
+++ b/state-fold/src/env/mod.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 mod archive;
 mod environment;
 mod global_archive;

--- a/state-fold/src/env/train.rs
+++ b/state-fold/src/env/train.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::error::*;
 use crate::Foldable;
 

--- a/state-fold/src/error.rs
+++ b/state-fold/src/error.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::Foldable;
 
 use eth_block_history::BlockArchiveError;

--- a/state-fold/src/foldable.rs
+++ b/state-fold/src/foldable.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::error::*;
 use crate::{FoldMiddleware, StateFoldEnvironment, SyncMiddleware};
 

--- a/state-fold/src/lib.rs
+++ b/state-fold/src/lib.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 #![allow(clippy::module_inception)]
 #![allow(clippy::too_many_arguments)]
 

--- a/state-fold/src/test_utils/mocks.rs
+++ b/state-fold/src/test_utils/mocks.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::{FoldMiddleware, Foldable, StateFoldEnvironment, SyncMiddleware};
 
 use eth_state_fold_test::mock_middleware::MockError;

--- a/state-fold/src/test_utils/mod.rs
+++ b/state-fold/src/test_utils/mod.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 pub(crate) mod mocks;
 
 mod utils;

--- a/state-fold/src/test_utils/utils.rs
+++ b/state-fold/src/test_utils/utils.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::StateFoldEnvironment;
 
 use eth_state_fold_types::ethers;

--- a/state-fold/src/utils.rs
+++ b/state-fold/src/utils.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use eth_state_fold_types::{ethabi, ethers};
 
 use ethabi::ethereum_types::BloomInput;

--- a/state-server-common/Cargo.toml
+++ b/state-server-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eth-state-server-common"
 license = "Apache-2.0"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
 homepage = "https://cartesi.io"
 edition = "2021"

--- a/state-server-common/Cargo.toml
+++ b/state-server-common/Cargo.toml
@@ -20,14 +20,14 @@ client = []
 [dependencies]
 eth-state-fold-types = { workspace = true }
 
-prost = "0.11"
-tonic = "0.8"
+prost = { workspace = true }
+tonic = { workspace = true }
 
-serde = "1"
-serde_json = "1"
-snafu = "0.7"
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
 
 
 [build-dependencies]
-tonic-build = "0.8"
-anyhow = "1"
+tonic-build = { workspace = true }
+anyhow = { workspace = true }

--- a/state-server-common/Cargo.toml
+++ b/state-server-common/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "eth-state-server-common"
-license = "Apache-2.0"
-version = "0.7.0"
-authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
-homepage = "https://cartesi.io"
-edition = "2021"
+
 include = [
     "build.rs",
     "**/*.rs",
@@ -12,10 +8,18 @@ include = [
     "grpc-interfaces/*.proto"
 ]
 
+license = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+
+
 [features]
 default = ["client"]
 server = []
 client = []
+
 
 [dependencies]
 eth-state-fold-types = { workspace = true }

--- a/state-server-common/build.rs
+++ b/state-server-common/build.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use anyhow::Result;
 use std::path::PathBuf;
 

--- a/state-server-common/src/conversions.rs
+++ b/state-server-common/src/conversions.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 use crate::grpc_interface::state_fold_server::{
     block_stream_response::Response as GrpcBlockStreamResponse,
     blocks_since_response::Response as GrpcBlocksSince, query_block::Id,

--- a/state-server-common/src/grpc_interface.rs
+++ b/state-server-common/src/grpc_interface.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 pub mod state_fold_server {
     tonic::include_proto!("state_fold_server");
 }

--- a/state-server-common/src/lib.rs
+++ b/state-server-common/src/lib.rs
@@ -1,3 +1,6 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
 #![allow(clippy::module_inception)]
 
 pub mod conversions;

--- a/state-server-lib/Cargo.toml
+++ b/state-server-lib/Cargo.toml
@@ -12,13 +12,13 @@ eth-state-server-common = { workspace = true, features = ["server"] }
 eth-state-fold = { workspace = true }
 eth-state-fold-types = { workspace = true }
 
-futures = "0.3"
-tonic = "0.8"
-tonic-health = "0.7"
-tokio = { version = "1", features = ["sync", "signal"] }
-tokio-stream = "0.1"
-tracing = "0.1"
-serde = "1"
-serde_json = "1"
-snafu = "0.7"
-clap = { version = "4.1", features = ["derive", "env"] }
+futures = { workspace = true }
+tonic = { workspace = true }
+tonic-health = { workspace = true }
+tokio = { features = ["sync", "signal"] , workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+clap = { features = ["derive", "env"] , workspace = true }

--- a/state-server-lib/Cargo.toml
+++ b/state-server-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eth-state-server-lib"
 license = "Apache-2.0"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
 homepage = "https://cartesi.io"
 edition = "2021"

--- a/state-server-lib/Cargo.toml
+++ b/state-server-lib/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "eth-state-server-lib"
-license = "Apache-2.0"
-version = "0.7.0"
-authors = ["Gabriel Coutinho de Paula <gabriel.coutinho@cartesi.io>"]
-homepage = "https://cartesi.io"
-edition = "2021"
+
+license = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+
 
 [dependencies]
 eth-block-history = { workspace = true }

--- a/state-server-lib/src/config.rs
+++ b/state-server-lib/src/config.rs
@@ -1,3 +1,5 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 use clap::Parser;
 use snafu::{ResultExt, Snafu};
 

--- a/state-server-lib/src/grpc_server.rs
+++ b/state-server-lib/src/grpc_server.rs
@@ -1,3 +1,5 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 use eth_state_server_common::state_fold_server;
 use state_fold_server::state_fold_server::StateFold;
 use state_fold_server::{

--- a/state-server-lib/src/lib.rs
+++ b/state-server-lib/src/lib.rs
@@ -1,3 +1,5 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 pub mod config;
 pub mod grpc_server;
 pub mod utils;

--- a/state-server-lib/src/utils.rs
+++ b/state-server-lib/src/utils.rs
@@ -1,3 +1,5 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 use crate::grpc_server::StateServer;
 
 use eth_state_fold::Foldable;


### PR DESCRIPTION
Hoist dependencies versioning to workspace `Cargo.toml`.